### PR TITLE
[Fix] Inject delete form action on edit pages

### DIFF
--- a/src/Resources/views/crud/edit.html.twig
+++ b/src/Resources/views/crud/edit.html.twig
@@ -147,11 +147,12 @@
 
             $('.action-delete').on('click', function(e) {
                 e.preventDefault();
+                const formAction = $(this).attr('formaction');
 
                 $('#modal-delete').modal({ backdrop: true, keyboard: true })
                     .off('click', '#modal-delete-button')
                     .on('click', '#modal-delete-button', function () {
-                        $('#delete-form').trigger('submit');
+                        $('#delete-form').attr('action', formAction).trigger('submit');
                     });
             });
         });


### PR DESCRIPTION
I recently noticed I could not delete an entity from its edit page. Apparently something was forgotten as the delete form action was not injected.

Here's a PR to fix that.